### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,10 +29,10 @@ RoxygenNote: 7.1.1
 Biarch: true
 Depends: R (>= 3.4.0)
 Imports: methods, Rcpp (>= 0.12.0), rstan (>=
-        2.18.1), vegan, rstantools (>= 2.1.1), tibble
+        2.26.0), vegan, rstantools (>= 2.1.1), tibble
 LinkingTo: BH (>= 1.66.0), Rcpp (>= 0.12.0), RcppEigen (>= 0.3.3.3.0),
-        RcppParallel (>= 5.0.1), rstan (>= 2.18.1), StanHeaders (>=
-        2.18.0)
+        RcppParallel (>= 5.0.1), rstan (>= 2.26.0), StanHeaders (>=
+        2.26.0)
 SystemRequirements: GNU make
 Repository: CRAN
 NeedsCompilation: yes

--- a/inst/stan/dm.stan
+++ b/inst/stan/dm.stan
@@ -3,16 +3,16 @@ data {
   int<lower=1> nreps;
   int<lower=1> notus;
 
-  int<lower=1> start[N];
-  int<lower=1> end[N];
+  array[N] int<lower=1> start;
+  array[N] int<lower=1> end;
 
-  int datamatrix[nreps, notus];
+  array[nreps, notus] int datamatrix;
 }
 
 parameters {
-  real<lower=0> theta[N];
-  simplex[notus] pi[N];
-  simplex[notus] p[nreps];
+  array[N] real<lower=0> theta;
+  array[N] simplex[notus] pi;
+  array[nreps] simplex[notus] p;
 }
 
 model {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
